### PR TITLE
feat: force architecture on docker pull

### DIFF
--- a/docker/package.json
+++ b/docker/package.json
@@ -4,7 +4,8 @@
   "description": "AFK - Away From Keyboard - Docker image",
   "scripts": {
     "build": "docker build -t afk .",
-    "pull": "docker pull crimsonronin/afk:latest",
+    "pull": "docker pull --platform linux/amd64 crimsonronin/afk:latest",
+    "pull:arm64": "docker pull --platform linux/arm64 crimsonronin/afk:latest",
     "rebuild": "docker build --no-cache -t afk .",
     "build:force": "docker build --no-cache --pull -t afk ."
   },


### PR DESCRIPTION
Adds platform specification to docker pull commands in docker/package.json to support non-linux/amd64 systems.

- Modified default pull script to use --platform linux/amd64
- Added pull:arm64 script for ARM64 architecture support

Closes #10

Generated with [Claude Code](https://claude.ai/code)