### PR TITLE
fix(electron): Default packaging to --publish never

### DIFF
--- a/electron/scripts/package.js
+++ b/electron/scripts/package.js
@@ -14,10 +14,14 @@ try {
   execSync('npm prune --omit=dev', { cwd: serverDir, stdio: 'inherit' });
 
   console.log(`[3/4] Packaging with electron-builder...`);
-  execSync(`npx electron-builder --config electron-builder.config.js ${args}`, {
-    cwd: electronDir,
-    stdio: 'inherit',
-  });
+  const publishFlag = args.includes('--publish') ? '' : '--publish never';
+  execSync(
+    `npx electron-builder --config electron-builder.config.js ${publishFlag} ${args}`,
+    {
+      cwd: electronDir,
+      stdio: 'inherit',
+    },
+  );
 } finally {
   console.log('[4/4] Restoring server devDependencies...');
   execSync('npm install', { cwd: serverDir, stdio: 'inherit' });

--- a/electron/src/updater.ts
+++ b/electron/src/updater.ts
@@ -95,8 +95,7 @@ export function checkForUpdates(): void {
       );
       setTimeout(() => checkForUpdates(), retryDelay);
     } else {
-      const errorMessage =
-        err instanceof Error ? err.message : 'Unknown error';
+      const errorMessage = err instanceof Error ? err.message : 'Unknown error';
       updateState = {
         status: 'error',
         error: `Update check failed after ${MAX_UPDATE_RETRIES} attempts: ${errorMessage}`,
@@ -121,9 +120,8 @@ function notifyRenderer(): void {
 
 function promptInstall(version: string): void {
   const window = getMainWindow();
-  const parent: BrowserWindow | undefined = window && !window.isDestroyed()
-    ? window
-    : undefined;
+  const parent: BrowserWindow | undefined =
+    window && !window.isDestroyed() ? window : undefined;
 
   dialog
     .showMessageBox({


### PR DESCRIPTION
Default `electron/scripts/package.js` to pass `--publish never` to electron-builder unless the caller includes `--publish` in the arguments. Local or CI packaging runs no longer attempt to publish releases when that was not intended.

Formatting-only tweaks in `updater.ts` from Prettier.


Made with [Cursor](https://cursor.com)