### PR TITLE
feat(desktop): add About tab and tray version display

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -39,6 +39,8 @@ ipcMain.handle('updater:get-state', () => {
   return getUpdateState();
 });
 
+ipcMain.handle('app:get-version', () => app.getVersion());
+
 app.on('window-all-closed', () => {
   // On macOS, keep the app alive in the tray when all windows are closed.
   // On other platforms, quit as usual.

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -3,6 +3,7 @@ import type { UpdateState } from './updater';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   platform: process.platform,
+  getAppVersion: () => ipcRenderer.invoke('app:get-version') as Promise<string>,
   versions: {
     electron: process.versions.electron,
     node: process.versions.node,

--- a/electron/src/tray.ts
+++ b/electron/src/tray.ts
@@ -151,6 +151,14 @@ function buildMenuTemplate(): MenuItemConstructorOptions[] {
     ...buildUpdateMenuItems(),
     { type: 'separator' },
     {
+      label: `Version ${app.getVersion()}`,
+      enabled: false,
+    },
+    {
+      label: 'About',
+      click: () => openRoute('/settings?tab=about'),
+    },
+    {
       label: 'Settings',
       click: () => openRoute('/settings'),
     },

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -7,8 +7,9 @@ import { GeneralSettings } from './settings/GeneralSettings';
 import { GitSettings } from './settings/GitSettings';
 import { DockerSettings } from './settings/DockerSettings';
 import { DataManagementSettings } from './settings/DataManagementSettings';
+import { AboutSettings } from './settings/AboutSettings';
 
-const TAB_KEYS = ['general', 'git', 'docker', 'data'] as const;
+const TAB_KEYS = ['general', 'git', 'docker', 'data', 'about'] as const;
 type TabKey = (typeof TAB_KEYS)[number];
 
 const Settings: React.FC = () => {
@@ -89,12 +90,14 @@ const Settings: React.FC = () => {
         <Tab label="Git" />
         <Tab label="Docker" />
         <Tab label="Data" />
+        <Tab label="About" />
       </Tabs>
 
       {activeTab === 0 && <GeneralSettings />}
       {activeTab === 1 && <GitSettings />}
       {activeTab === 2 && <DockerSettings />}
       {activeTab === 3 && <DataManagementSettings />}
+      {activeTab === 4 && <AboutSettings />}
     </Box>
   );
 };

--- a/web/src/pages/settings/AboutSettings.tsx
+++ b/web/src/pages/settings/AboutSettings.tsx
@@ -1,0 +1,212 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  CircularProgress,
+  Alert,
+} from '@mui/material';
+import { apiClient } from '../../api/client';
+import { afkColors } from '../../themes/afk';
+import type { UpdateState } from '../../types/electron';
+
+const SectionHeader: React.FC<{ title: string }> = ({ title }) => (
+  <Box
+    sx={{
+      borderLeft: `2px solid ${afkColors.accent}`,
+      pl: 2,
+      mb: 2.5,
+    }}
+  >
+    <Typography variant="h5" sx={{ color: afkColors.textPrimary }}>
+      {title}
+    </Typography>
+  </Box>
+);
+
+interface HealthLivePayload {
+  version?: string;
+}
+
+const AboutSettings: React.FC = () => {
+  const [desktopVersion, setDesktopVersion] = useState<string | null>(null);
+  const [desktopLoading, setDesktopLoading] = useState(true);
+  const [serverVersion, setServerVersion] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [serverLoading, setServerLoading] = useState(true);
+
+  const [updateState, setUpdateState] = useState<UpdateState | null>(null);
+
+  useEffect(() => {
+    const api = window.electronAPI;
+    if (!api?.getAppVersion) {
+      setDesktopVersion(null);
+      setDesktopLoading(false);
+      return;
+    }
+
+    void api
+      .getAppVersion()
+      .then((v) => setDesktopVersion(v))
+      .catch(() => setDesktopVersion(null))
+      .finally(() => setDesktopLoading(false));
+  }, []);
+
+  useEffect(() => {
+    void apiClient
+      .get<HealthLivePayload>('/health/live')
+      .then((data) => {
+        const payload = data as unknown as HealthLivePayload;
+        setServerVersion(
+          typeof payload?.version === 'string' ? payload.version : null,
+        );
+        setServerError(null);
+      })
+      .catch((err: unknown) => {
+        setServerVersion(null);
+        const message = err instanceof Error ? err.message : 'Failed to load';
+        setServerError(message);
+      })
+      .finally(() => setServerLoading(false));
+  }, []);
+
+  useEffect(() => {
+    const api = window.electronAPI?.updater;
+    if (!api) {
+      return;
+    }
+
+    void api.getState().then(setUpdateState);
+
+    const unsubscribe = api.onStateChanged(setUpdateState);
+    return unsubscribe;
+  }, []);
+
+  const handleCheckForUpdates = useCallback(() => {
+    void window.electronAPI?.updater?.checkForUpdates();
+  }, []);
+
+  const handleInstallUpdate = useCallback(() => {
+    void window.electronAPI?.updater?.install();
+  }, []);
+
+  const renderUpdaterSection = () => {
+    const api = window.electronAPI?.updater;
+    if (!api) {
+      return (
+        <Typography variant="body2" sx={{ color: afkColors.textSecondary }}>
+          Software updates are only available in the AFK desktop app.
+        </Typography>
+      );
+    }
+
+    const state = updateState ?? { status: 'idle' as const };
+
+    switch (state.status) {
+      case 'checking':
+        return (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <CircularProgress size={16} />
+            <Typography variant="body2" sx={{ color: afkColors.textSecondary }}>
+              Checking for updates…
+            </Typography>
+          </Box>
+        );
+      case 'downloading':
+        return (
+          <Typography variant="body2" sx={{ color: afkColors.textSecondary }}>
+            Downloading update… {state.progress ?? 0}%
+          </Typography>
+        );
+      case 'downloaded':
+        return (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            <Typography variant="body2" sx={{ color: afkColors.textSecondary }}>
+              Update is ready to install.
+            </Typography>
+            <Button variant="contained" onClick={handleInstallUpdate}>
+              Restart to update
+              {state.version ? ` (v${state.version})` : ''}
+            </Button>
+          </Box>
+        );
+      case 'available':
+        return (
+          <Typography variant="body2" sx={{ color: afkColors.textSecondary }}>
+            Update available{state.version ? ` (v${state.version})` : ''}.
+          </Typography>
+        );
+      case 'error':
+        return (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            {state.error && (
+              <Alert severity="warning" sx={{ py: 0.5 }}>
+                {state.error}
+              </Alert>
+            )}
+            <Button variant="outlined" onClick={handleCheckForUpdates}>
+              Check for updates
+            </Button>
+          </Box>
+        );
+      default:
+        return (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            <Typography variant="body2" sx={{ color: afkColors.textSecondary }}>
+              {state.status === 'not-available'
+                ? 'You are on the latest version.'
+                : 'Check whether a newer version is available.'}
+            </Typography>
+            <Button variant="outlined" onClick={handleCheckForUpdates}>
+              Check for updates
+            </Button>
+          </Box>
+        );
+    }
+  };
+
+  return (
+    <>
+      <Box sx={{ mb: 4 }}>
+        <SectionHeader title="AFK Desktop" />
+        {desktopLoading ? (
+          <CircularProgress size={20} />
+        ) : desktopVersion ? (
+          <Typography variant="body1" sx={{ color: afkColors.textPrimary }}>
+            Version {desktopVersion}
+          </Typography>
+        ) : (
+          <Typography variant="body2" sx={{ color: afkColors.textSecondary }}>
+            Not running in the desktop app (or version unavailable).
+          </Typography>
+        )}
+      </Box>
+
+      <Box sx={{ mb: 4 }}>
+        <SectionHeader title="AFK Server" />
+        {serverLoading ? (
+          <CircularProgress size={20} />
+        ) : serverError ? (
+          <Typography variant="body2" sx={{ color: afkColors.danger }}>
+            {serverError}
+          </Typography>
+        ) : serverVersion ? (
+          <Typography variant="body1" sx={{ color: afkColors.textPrimary }}>
+            Version {serverVersion}
+          </Typography>
+        ) : (
+          <Typography variant="body2" sx={{ color: afkColors.textSecondary }}>
+            Version unknown
+          </Typography>
+        )}
+      </Box>
+
+      <Box>
+        <SectionHeader title="Updates" />
+        {renderUpdaterSection()}
+      </Box>
+    </>
+  );
+};
+
+export { AboutSettings };

--- a/web/src/types/electron.d.ts
+++ b/web/src/types/electron.d.ts
@@ -11,7 +11,7 @@ interface TrayState {
   upcomingJobs: TrayMenuLink[];
 }
 
-type UpdateStatus =
+export type UpdateStatus =
   | 'idle'
   | 'checking'
   | 'available'
@@ -20,7 +20,7 @@ type UpdateStatus =
   | 'downloaded'
   | 'error';
 
-interface UpdateState {
+export interface UpdateState {
   status: UpdateStatus;
   version?: string;
   error?: string;
@@ -36,6 +36,7 @@ interface ElectronUpdaterAPI {
 
 interface ElectronAPI {
   platform: string;
+  getAppVersion: () => Promise<string>;
   versions: { electron: string; node: string; chrome: string };
   openExternal: (url: string) => Promise<void>;
   updateTrayState: (state: TrayState) => void;
@@ -47,5 +48,3 @@ declare global {
     electronAPI?: ElectronAPI;
   }
 }
-
-export {};


### PR DESCRIPTION
# Summary

Users could not see which AFK desktop build they were running despite auto-updates. This adds an About area in Settings and surfaces the current app version in the tray menu, plus IPC so the renderer can read `app.getVersion()`.

## Changes

- Expose desktop app version via `app:get-version` IPC and `electronAPI.getAppVersion()`.
- Add Settings **About** tab (`AboutSettings`) with desktop version, server version from `GET /api/health/live`, and updater status/actions aligned with the tray.
- Tray: disabled **Version** line and **About** (opens `/settings?tab=about`); export `UpdateState` types from `electron.d.ts` for the About UI.

## Related Issues

N/A

## Testing

```bash
npm run format
cd web && npm run build
cd ../electron && npx tsc --noEmit
```

Manual: open Settings → About in the desktop app; confirm version matches tray; web-only dev shows server version and no desktop version.

## Screenshots or Recordings

N/A

## Breaking Changes

None

## Contributor Checklist

- [x] This PR is focused on a single change and avoids unrelated cleanup.
- [x] I ran `npm run format`.
- [x] I ran relevant validation locally, such as `npm run test`, or a targeted build.
- [x] I added or updated tests when behavior changed, or explained why tests were not needed.
- [x] I updated docs, screenshots, or setup notes when user-facing behavior changed.
- [x] I called out any breaking changes, migrations, or security-sensitive changes.
- [x] I am not including secrets, credentials, or unrelated generated files.

## Additional Context

Root `package.json` and `electron/package.json` versions may still differ; displayed desktop version follows Electron’s `app.getVersion()` (electron package).
