### PR TITLE
fix(electron): let updater-triggered restarts close cleanly

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -91,6 +91,11 @@ app.whenReady().then(async () => {
 
 app.on('before-quit', async () => {
   setIsQuitting(true);
+  const mainWin = getMainWindow();
+  if (mainWin && !mainWin.isDestroyed()) {
+    // Detached DevTools can block main window close; always tear it down on quit.
+    mainWin.webContents.closeDevTools();
+  }
   destroyTray();
   await stopServer();
 });

--- a/electron/src/window.ts
+++ b/electron/src/window.ts
@@ -75,15 +75,18 @@ export function createWindow(): void {
   }
 
   mainWindow.on('close', (event) => {
+    const isQuitting = getIsQuitting();
+    // Allow programmatic quit (updates, app.quit) even while the install overlay
+    // has set updateInstalling — otherwise quit never completes.
+    if (isQuitting) {
+      return;
+    }
     if (updateInstalling) {
       event.preventDefault();
       return;
     }
-    if (!getIsQuitting()) {
-      event.preventDefault();
-      mainWindow?.hide();
-      return;
-    }
+    event.preventDefault();
+    mainWindow?.hide();
   });
 
   mainWindow.on('closed', () => {
@@ -97,7 +100,7 @@ export function getMainWindow(): BrowserWindow | null {
 
 export function setUpdateInstalling(value: boolean): void {
   updateInstalling = value;
-  if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.setClosable(!value);
-  }
+  // Do not call setClosable(false) during updates: on macOS that can prevent
+  // app.quit() / quitAndInstall from closing the window (electron#5680). User
+  // close while installing is still blocked in the 'close' handler below.
 }


### PR DESCRIPTION
Allow updater-triggered restarts to close the main window cleanly.

The update install flow could leave the Electron window non-closable while the
window close handler was still blocking shutdown when `updateInstalling` was
set. That meant `app.quit()` and `quitAndInstall()` could stall instead of
restarting the app after an update was ready.

I considered keeping `setClosable(false)` and adding more special cases around
window shutdown, but that was fighting Electron/macOS close behavior. This
change keeps user-initiated closes blocked in the `close` handler while still
allowing programmatic quits to proceed, and it also closes detached DevTools on
quit because that can block the main window from exiting.

Made with [Cursor](https://cursor.com)