### PR TITLE
chore(docker): Use latest Claude Code version

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim
 
-ARG CLAUDE_CODE_VERSION=2.1.42
+ARG CLAUDE_CODE_VERSION=latest
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   less \


### PR DESCRIPTION
Use the latest Claude Code package when building the base Docker image instead of pinning to 2.1.42.

This keeps newly built agent containers aligned with the current Claude CLI release without requiring a repository change for each upstream version bump. The PR also keeps the Claude plugins directory present in the Docker context with a placeholder file.

Made with [Cursor](https://cursor.com)